### PR TITLE
Pull decimals from token directly

### DIFF
--- a/contracts/OFTWrapper.sol
+++ b/contracts/OFTWrapper.sol
@@ -28,7 +28,7 @@ contract OFTWrapper is OFTCore, RateLimiter {
         address _lzEndpoint,
         address _delegate,
         RateLimitConfig[] memory _rateLimitConfigs
-    ) OFTCore(6, _lzEndpoint, _delegate) {
+    ) OFTCore(PaxosTokenV2(_paxosToken).decimals(), _lzEndpoint, _delegate) {
         paxosToken = PaxosTokenV2(_paxosToken);
         _setRateLimits(_rateLimitConfigs);
     }

--- a/contracts/fixture/PaxosTokenFixture.sol
+++ b/contracts/fixture/PaxosTokenFixture.sol
@@ -15,4 +15,8 @@ contract PaxosTokenFixture is PaxosTokenV2 {
         balances[burnFromAddress] -= value;
         return true;
     }
+    
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
 }

--- a/test/OFTProxyBasicTest.js
+++ b/test/OFTProxyBasicTest.js
@@ -19,6 +19,13 @@ describe('OFTWrapper Test', function () {
       });
     });
 
+    describe('decimalConversionRate', function () {
+      it('can get decimal conversion rate', async function () {
+        let res = await this.contract.decimalConversionRate();
+        assert.equal(res, 1)
+      });
+    });
+
     describe('token', function () {
       it('can get token address', async function () {
         let res = await this.contract.token();
@@ -42,7 +49,6 @@ describe('OFTWrapper Test', function () {
         }
         await this.contract.setRateLimits([newRateLimitConfig])
         const rateLimitConfig = await this.contract.rateLimits(newRateLimitConfig.dstEid);
-        console.log(rateLimitConfig)
         assert.equal(rateLimitConfig.limit.toString(), newRateLimitConfig.limit.toString())
         assert.equal(rateLimitConfig.window, newRateLimitConfig.window)
       });

--- a/test/OFTProxySendTest.js
+++ b/test/OFTProxySendTest.js
@@ -60,12 +60,12 @@ describe('OFTWrapper Send Test', function () {
       dstEid: 2,
       limit: ethers.utils.parseEther('1000'),
       window: 100
-   }
+    }
     const rateLimitConfigB = {
       dstEid: 1,
       limit: ethers.utils.parseEther('1000'),
       window: 100
-   }
+    }
     myOFTA = await MyOFT.connect(ownerA).deploy(tokenFixture.address, mockEndpointA.address, ownerA.address, [rateLimitConfigA])
     myOFTB = await MyOFT.connect(ownerB).deploy(tokenFixtureB.address, mockEndpointB.address, ownerB.address, [rateLimitConfigB])
 


### PR DESCRIPTION
- Addresses audit findings where decimals were being hardcoded.